### PR TITLE
Read team from bucket object with right property

### DIFF
--- a/internal/runscope/bucket.go
+++ b/internal/runscope/bucket.go
@@ -33,7 +33,7 @@ func BucketFromSchema(s *schema.Bucket) *Bucket {
 		Name: s.Name,
 		Team: Team{
 			Name: s.Team.Name,
-			UUID: s.Team.UUID,
+			UUID: s.Team.ID,
 		},
 		AuthToken:  s.AuthToken,
 		Default:    s.Default,

--- a/internal/runscope/schema/account.go
+++ b/internal/runscope/schema/account.go
@@ -1,10 +1,15 @@
 package schema
 
+type AccountTeam struct {
+	Name string `json:"name"`
+	UUID string `json:"uuid"`
+}
+
 type Account struct {
-	Name  string `json:"name"`
-	UUID  string `json:"uuid"`
-	Email string `json:"email"`
-	Teams []Team `json:"teams"`
+	Name  string        `json:"name"`
+	UUID  string        `json:"uuid"`
+	Email string        `json:"email"`
+	Teams []AccountTeam `json:"teams"`
 }
 
 type AccountResponse struct {

--- a/internal/runscope/schema/bucket.go
+++ b/internal/runscope/schema/bucket.go
@@ -1,13 +1,18 @@
 package schema
 
+type BucketTeam struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
 type Bucket struct {
-	Key        string `json:"key"`
-	Name       string `json:"name"`
-	Team       Team   `json:"team"`
-	AuthToken  string `json:"auth_token"`
-	Default    bool   `json:"default"`
-	VerifySSL  bool   `json:"verify_ssl"`
-	TriggerURL string `json:"trigger_url"`
+	Key        string     `json:"key"`
+	Name       string     `json:"name"`
+	Team       BucketTeam `json:"team"`
+	AuthToken  string     `json:"auth_token"`
+	Default    bool       `json:"default"`
+	VerifySSL  bool       `json:"verify_ssl"`
+	TriggerURL string     `json:"trigger_url"`
 }
 
 type BucketCreateResponse struct {

--- a/internal/runscope/schema/team.go
+++ b/internal/runscope/schema/team.go
@@ -1,6 +1,0 @@
-package schema
-
-type Team struct {
-	Name string `json:"name"`
-	UUID string `json:"uuid"`
-}


### PR DESCRIPTION
Runscope API is kinda bonkers that some endpoints return `uuid` for the
team ID (e.g. `/account`), but return `id` for other endpoints (e.g
. `/buckets/{id}`).

Use separate structs to fix this so the bucket isn't recreated all the
time.